### PR TITLE
玉と壁とリラックマの描画の設定変更

### DIFF
--- a/characters/Rilakkuma.c
+++ b/characters/Rilakkuma.c
@@ -212,7 +212,7 @@ void ktleg(void) {
 	glMaterialfv(GL_FRONT, GL_DIFFUSE, ktface);
 	glMaterialfv(GL_FRONT, GL_AMBIENT, ktblack);
 	glMaterialfv(GL_FRONT, GL_SPECULAR, ktwhite);
-	glMaterialf(GL_FRONT, GL_SHININESS, 1000.0);
+	//glMaterialf(GL_FRONT, GL_SHININESS, 1000.0);
 	ktCylinder(2.0);
 	leg_inside();
 	glTranslatef(-3.4, 0.0, 0.0);

--- a/object/object.c
+++ b/object/object.c
@@ -4,6 +4,7 @@
 #include <math.h>
 #include <string.h>
 
+
 #ifndef M_PI
 	#define M_PI 3.14159265358979323846
 #endif

--- a/object/object.c
+++ b/object/object.c
@@ -4,7 +4,6 @@
 #include <math.h>
 #include <string.h>
 
-
 #ifndef M_PI
 	#define M_PI 3.14159265358979323846
 #endif

--- a/object/object.c
+++ b/object/object.c
@@ -8,7 +8,7 @@
 	#define M_PI 3.14159265358979323846
 #endif
 
-enum COLOR { WHITE, BROWN, ORANGE, GRAY, BLACK };
+enum COLOR { WHITE, BROWN, ORANGE, GRAY, BLACK};
 GLfloat color[][4] = {
 	{ 1.0, 1.0, 1.0, 1.0 },
 	{ 0.5, 0.4, 0.35, 1.0 },
@@ -17,27 +17,8 @@ GLfloat color[][4] = {
 	{ 0.0, 0.0, 0.0, 1.0 }
 };
 
-void calcNormal(GLdouble v0[3], GLdouble v1[3], GLdouble v2[3], GLdouble n[3])
-{
-	GLdouble v2v[2][3];
-	GLdouble vt[3];
-	double abs;
-	int i;
-	for (i = 0; i < 3; i++)
-	{
-		v2v[0][i] = v1[i] - v0[i];
-		v2v[1][i] = v2[i] - v0[i];
-	}
-	vt[0] = v2v[0][1] * v2v[1][2] - v2v[0][2] * v2v[1][1];
-	vt[1] = v2v[0][2] * v2v[1][0] - v2v[0][0] * v2v[1][2];
-	vt[2] = v2v[0][0] * v2v[1][1] - v2v[0][1] * v2v[1][0];
-	abs = sqrt(vt[0] * vt[0] + vt[1] * vt[1] + vt[2] * vt[2]);
-	for (i = 0; i < 3; i++)
-		n[i] = vt[i] / abs;
-}
-
 void draw_ground(void){
-    int i, j;
+    //int i, j;
 	glPushMatrix();
 	// glScalef(FIELD_MAX_X, FIELD_MAX_Y, FIELD_MAX_Z);
 	glBegin(GL_QUADS);
@@ -92,7 +73,8 @@ void draw_snowman(Coordinate *location){
 }
 
 void draw_bullet(Coordinate *location){
-    glMaterialfv(GL_FRONT, GL_AMBIENT_AND_DIFFUSE, color[WHITE]);
+	glMaterialfv(GL_FRONT, GL_DIFFUSE, color[WHITE]);
+	glMaterialfv(GL_FRONT, GL_AMBIENT, color[BLACK]);
     glMaterialf(GL_FRONT, GL_SHININESS, 100.0);
     glPushMatrix();
     glTranslatef(location->x,2,location->z);
@@ -102,7 +84,9 @@ void draw_bullet(Coordinate *location){
 
 
 void draw_wall(Coordinate *location){
-	glMaterialfv(GL_FRONT, GL_AMBIENT_AND_DIFFUSE, color[GRAY]);
+	//glMaterialfv(GL_FRONT, GL_AMBIENT_AND_DIFFUSE, color[GRAY]);
+	glMaterialfv(GL_FRONT, GL_DIFFUSE, color[GRAY]);
+	glMaterialfv(GL_FRONT, GL_AMBIENT, color[BLACK]);
     glMaterialf(GL_FRONT, GL_SHININESS, 100.0);
     glPushMatrix();
 	glTranslatef(location->x,location->y,location->z);


### PR DESCRIPTION
玉とシールドが見えるようにしました。
あとは使っていなかったobject.cのdraw_calculate関数と、地面を描画する関数内のiとjを消去しました。
確認お願いいたします。