### PR TITLE
wsclient内で発生するセグフォの修正

### DIFF
--- a/websocket/ws_api/wsclient.c
+++ b/websocket/ws_api/wsclient.c
@@ -177,13 +177,15 @@ void libwsclient_handle_control_frame(wsclient *c, wsclient_frame *ctl_frame) {
 		case 0x9:
 			// Received ping frame
 			if((c->flags & CLIENT_SHOULD_CLOSE) == 0) {
-				// set mask
+				// Server sent ping.  Send pong frame as acknowledgement.
+				*(ctl_frame->rawdata + 1) |= 0x80; //turn mask bit on
+				// mask payload, but shift 4 bytes to make place to set the masking-key
+				for (i = ctl_frame->payload_len - 1; i >= 0; i--) {
+					*(ctl_frame->rawdata + ctl_frame->payload_offset + i + 4) = *(ctl_frame->rawdata + ctl_frame->payload_offset + i) ^ (mask[i % 4] & 0xff);
+				}
+				// set masking-key
 				memcpy(ctl_frame->rawdata + ctl_frame->payload_offset, mask, 4);
 				ctl_frame->payload_offset += 4;
-				// Server sent ping.  Send pong frame as acknowledgement.
-				for(i=0;i<ctl_frame->payload_len;i++)
-					*(ctl_frame->rawdata + ctl_frame->payload_offset + i) ^= (mask[i % 4] & 0xff); //mask payload
-				*(ctl_frame->rawdata + 1) |= 0x80; //turn mask bit on
 				i = 0;
 				// change opcode to 0xA (Pong Frame)
 				*(ctl_frame->rawdata) = (*(ctl_frame->rawdata) & 0xf0) | 0xA;


### PR DESCRIPTION
使用したライブラリのバグを取り除いてセグフォが起きないようにしました

確認よろしくおねがいします